### PR TITLE
Add initial macOS solver implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore saved game state
+nonogramSolver-July2025/gamestate.json

--- a/nonogramSolver-July2025/ClueEntryView.swift
+++ b/nonogramSolver-July2025/ClueEntryView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct ClueEntryView: View {
+    @ObservedObject var manager: GameManager
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Row Clues")
+            ForEach(0..<manager.grid.rows, id: \.self) { row in
+                TextField("Row \(row)", text: Binding(
+                    get: { manager.rowClues[row].map(String.init).joined(separator: " ") },
+                    set: { manager.updateRowClue(row: row, string: $0) }
+                ))
+                    .textFieldStyle(.roundedBorder)
+            }
+            Text("Column Clues")
+            ForEach(0..<manager.grid.columns, id: \.self) { column in
+                TextField("Col \(column)", text: Binding(
+                    get: { manager.columnClues[column].map(String.init).joined(separator: " ") },
+                    set: { manager.updateColumnClue(column: column, string: $0) }
+                ))
+                    .textFieldStyle(.roundedBorder)
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ClueEntryView(manager: GameManager())
+}

--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -1,21 +1,44 @@
-//
-//  ContentView.swift
-//  nonogramSolver-July2025
-//
-//  Created by Gabriel Alan Collins on 2025-06-13.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var manager = GameManager()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            VStack {
+                NonogramGridView(manager: manager)
+                ClueEntryView(manager: manager)
+            }
+            .padding()
+            .navigationTitle("Nonogram Solver")
+            .toolbar {
+                ToolbarItemGroup(placement: .navigation) {
+                    Picker("Rows", selection: Binding(
+                        get: { manager.grid.rows },
+                        set: { manager.set(rows: $0, columns: manager.grid.columns) }
+                    )) {
+                        ForEach(Array(stride(from: 5, through: 40, by: 5)), id: \.self) { value in
+                            Text("\(value)").tag(value)
+                        }
+                    }
+                    Picker("Columns", selection: Binding(
+                        get: { manager.grid.columns },
+                        set: { manager.set(rows: manager.grid.rows, columns: $0) }
+                    )) {
+                        ForEach(Array(stride(from: 5, through: 40, by: 5)), id: \.self) { value in
+                            Text("\(value)").tag(value)
+                        }
+                    }
+                }
+                ToolbarItemGroup(placement: .automatic) {
+                    Button("Auto Solve") { manager.autoSolve() }
+                    Button("Step Solve") { manager.stepSolve() }
+                }
+            }
         }
-        .padding()
+        .task {
+            await manager.load()
+        }
     }
 }
 

--- a/nonogramSolver-July2025/Data/testing.json
+++ b/nonogramSolver-July2025/Data/testing.json
@@ -1,0 +1,15 @@
+{
+  "grid": {
+    "rows": 5,
+    "columns": 5,
+    "tiles": [
+      ["unmarked","unmarked","unmarked","unmarked","unmarked"],
+      ["unmarked","unmarked","unmarked","unmarked","unmarked"],
+      ["unmarked","unmarked","unmarked","unmarked","unmarked"],
+      ["unmarked","unmarked","unmarked","unmarked","unmarked"],
+      ["unmarked","unmarked","unmarked","unmarked","unmarked"]
+    ]
+  },
+  "rowClues": [],
+  "columnClues": []
+}

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+@MainActor
+class GameManager: ObservableObject {
+    @Published private(set) var grid: PuzzleGrid
+    @Published var rowClues: [[Int]]
+    @Published var columnClues: [[Int]]
+
+    private let store = GameStateStore()
+
+    init() {
+        self.grid = PuzzleGrid(rows: 20, columns: 15)
+        self.rowClues = Array(repeating: [], count: grid.rows)
+        self.columnClues = Array(repeating: [], count: grid.columns)
+    }
+
+    func load() async {
+        if let state = await store.load() {
+            self.grid = state.grid
+            self.rowClues = state.rowClues
+            self.columnClues = state.columnClues
+        }
+    }
+
+    func save() async {
+        let state = GameState(grid: grid, rowClues: rowClues, columnClues: columnClues)
+        await store.save(state)
+    }
+
+    func set(rows: Int, columns: Int) {
+        grid = PuzzleGrid(rows: rows, columns: columns)
+        rowClues = Array(repeating: [], count: rows)
+        columnClues = Array(repeating: [], count: columns)
+        Task { await save() }
+    }
+
+    func tap(row: Int, column: Int) {
+        guard row < grid.rows, column < grid.columns else { return }
+        let current = grid.tiles[row][column]
+        let next: TileState
+        switch current {
+        case .unmarked:
+            next = .filled
+        case .filled:
+            next = .empty
+        case .empty:
+            next = .unmarked
+        }
+        grid.tiles[row][column] = next
+        Task { await save() }
+    }
+
+    func updateRowClue(row: Int, string: String) {
+        rowClues[row] = string.split(separator: " ").compactMap { Int($0) }
+        Task { await save() }
+    }
+
+    func updateColumnClue(column: Int, string: String) {
+        columnClues[column] = string.split(separator: " ").compactMap { Int($0) }
+        Task { await save() }
+    }
+
+    func autoSolve() {
+        // stub
+    }
+
+    func stepSolve() {
+        // stub
+    }
+}

--- a/nonogramSolver-July2025/NonogramGridView.swift
+++ b/nonogramSolver-July2025/NonogramGridView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+struct NonogramGridView: View {
+    @ObservedObject var manager: GameManager
+
+    var body: some View {
+        GeometryReader { geo in
+            let size = min(geo.size.width, geo.size.height)
+            let cellWidth = size / CGFloat(manager.grid.columns)
+            let cellHeight = size / CGFloat(manager.grid.rows)
+            ZStack {
+                // grid
+                ForEach(0..<manager.grid.rows, id: \.self) { row in
+                    ForEach(0..<manager.grid.columns, id: \.self) { column in
+                        Rectangle()
+                            .strokeBorder(lineWidth: lineWidth(row: row, column: column))
+                            .background(tileColor(manager.grid.tiles[row][column]))
+                            .frame(width: cellWidth, height: cellHeight)
+                            .position(x: cellWidth * (CGFloat(column) + 0.5), y: cellHeight * (CGFloat(row) + 0.5))
+                            .onTapGesture { manager.tap(row: row, column: column) }
+                    }
+                }
+            }
+        }
+        .aspectRatio(CGFloat(manager.grid.columns) / CGFloat(manager.grid.rows), contentMode: .fit)
+    }
+
+    func tileColor(_ state: TileState) -> some View {
+        switch state {
+        case .filled:
+            return Color.black
+        case .empty:
+            return Color.white.overlay(Text("x").font(.caption))
+        case .unmarked:
+            return Color.white
+        }
+    }
+
+    func lineWidth(row: Int, column: Int) -> CGFloat {
+        if row % 5 == 0 || column % 5 == 0 {
+            return 2
+        }
+        return 1
+    }
+}
+
+#Preview {
+    NonogramGridView(manager: GameManager())
+}

--- a/nonogramSolver-July2025/PuzzleModels.swift
+++ b/nonogramSolver-July2025/PuzzleModels.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum TileState: String, Codable {
+    case filled
+    case empty
+    case unmarked
+}
+
+struct PuzzleGrid: Codable {
+    var rows: Int
+    var columns: Int
+    var tiles: [[TileState]]
+
+    init(rows: Int, columns: Int, fill: TileState = .unmarked) {
+        self.rows = rows
+        self.columns = columns
+        self.tiles = Array(repeating: Array(repeating: fill, count: columns), count: rows)
+    }
+}
+
+struct GameState: Codable {
+    var grid: PuzzleGrid
+    var rowClues: [[Int]]
+    var columnClues: [[Int]]
+}

--- a/nonogramSolver-July2025/Services.swift
+++ b/nonogramSolver-July2025/Services.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+actor FlatFileController {
+    func url(for fileName: String) -> URL {
+        let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+        return paths[0].appendingPathComponent(fileName)
+    }
+
+    func save<T: Encodable>(_ value: T, to file: String) throws {
+        let data = try JSONEncoder().encode(value)
+        let url = url(for: file)
+        try data.write(to: url, options: [.atomic])
+    }
+
+    func load<T: Decodable>(_ file: String, as type: T.Type) throws -> T {
+        let url = url(for: file)
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}
+
+actor GameStateStore {
+    private let controller = FlatFileController()
+    private let fileName = "gamestate.json"
+
+    func save(_ state: GameState) async {
+        do {
+            try await controller.save(state, to: fileName)
+        } catch {
+            print("Failed to save state: \(error)")
+        }
+    }
+
+    func load() async -> GameState? {
+        do {
+            return try await controller.load(fileName, as: GameState.self)
+        } catch {
+            return nil
+        }
+    }
+}
+
+struct PuzzleService {
+    static func loadSamplePuzzle() -> GameState? {
+        guard let url = Bundle.main.url(forResource: "testing", withExtension: "json") else {
+            return nil
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(GameState.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/nonogramSolver-July2025Tests/nonogramSolver_July2025Tests.swift
+++ b/nonogramSolver-July2025Tests/nonogramSolver_July2025Tests.swift
@@ -1,17 +1,24 @@
-//
-//  nonogramSolver_July2025Tests.swift
-//  nonogramSolver-July2025Tests
-//
-//  Created by Gabriel Alan Collins on 2025-06-13.
-//
-
-import Testing
+import XCTest
 @testable import nonogramSolver_July2025
 
-struct nonogramSolver_July2025Tests {
+final class nonogramSolver_July2025Tests: XCTestCase {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    func testTileCycle() async {
+        let manager = GameManager()
+        manager.tap(row: 0, column: 0)
+        XCTAssertEqual(manager.grid.tiles[0][0], .filled)
+        manager.tap(row: 0, column: 0)
+        XCTAssertEqual(manager.grid.tiles[0][0], .empty)
+        manager.tap(row: 0, column: 0)
+        XCTAssertEqual(manager.grid.tiles[0][0], .unmarked)
     }
 
+    func testPersistence() async throws {
+        let manager = GameManager()
+        manager.tap(row: 0, column: 0)
+        await manager.save()
+        let newManager = GameManager()
+        await newManager.load()
+        XCTAssertEqual(newManager.grid.tiles[0][0], manager.grid.tiles[0][0])
+    }
 }


### PR DESCRIPTION
## Summary
- add persistent models and a simple puzzle sample
- implement persistence services and a game manager
- create grid, clue entry and toolbar UI
- add unit tests covering tile cycle and persistence
- ignore saved game state file

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684c67bd6a408330bbd9b2ffd3a36004