### PR TITLE
Add builder initialization with splash screen

### DIFF
--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject private var manager = GameManager()
+    @StateObject private var manager: GameManager
+
+    init(manager: GameManager) {
+        _manager = StateObject(wrappedValue: manager)
+    }
 
     var body: some View {
         NavigationStack {
@@ -36,12 +40,9 @@ struct ContentView: View {
                 }
             }
         }
-        .task {
-            await manager.load()
-        }
     }
 }
 
 #Preview {
-    ContentView()
+    ContentView(manager: GameManager())
 }

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -8,10 +8,19 @@ class GameManager: ObservableObject {
 
     private let store = GameStateStore()
 
-    init() {
-        self.grid = PuzzleGrid(rows: 20, columns: 15)
-        self.rowClues = Array(repeating: [], count: grid.rows)
-        self.columnClues = Array(repeating: [], count: grid.columns)
+    init(grid: PuzzleGrid, rowClues: [[Int]], columnClues: [[Int]]) {
+        self.grid = grid
+        self.rowClues = rowClues
+        self.columnClues = columnClues
+    }
+
+    convenience init() {
+        let rows = 20
+        let columns = 15
+        let grid = PuzzleGrid(rows: rows, columns: columns)
+        let rowClues = Array(repeating: [], count: rows)
+        let columnClues = Array(repeating: [], count: columns)
+        self.init(grid: grid, rowClues: rowClues, columnClues: columnClues)
     }
 
     func load() async {

--- a/nonogramSolver-July2025/GameManagerBuilder.swift
+++ b/nonogramSolver-July2025/GameManagerBuilder.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+struct GameManagerBuilder {
+    func build() async -> GameManager {
+        let manager = GameManager()
+        await manager.load()
+        return manager
+    }
+}

--- a/nonogramSolver-July2025/SplashView.swift
+++ b/nonogramSolver-July2025/SplashView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct SplashView: View {
+    @State private var manager: GameManager?
+
+    var body: some View {
+        Group {
+            if let manager = manager {
+                ContentView(manager: manager)
+            } else {
+                ProgressView("Loading...")
+                    .task {
+                        manager = await GameManagerBuilder().build()
+                    }
+            }
+        }
+    }
+}
+
+#Preview {
+    SplashView()
+}

--- a/nonogramSolver-July2025/nonogramSolver_July2025App.swift
+++ b/nonogramSolver-July2025/nonogramSolver_July2025App.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct nonogramSolver_July2025App: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            SplashView()
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix GameManager initialization to avoid referencing `self` before stored properties are ready
- create `GameManagerBuilder` to assemble the game state before UI loads
- show a `SplashView` that waits for the builder then launches the main content
- inject `GameManager` into `ContentView`

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684c8f59c0b08330a6d4ac6c50518514