### PR TITLE
Persist clues per grid size

### DIFF
--- a/RowColumnState_Plan.md
+++ b/RowColumnState_Plan.md
@@ -1,0 +1,23 @@
+# Plan for Row/Column Clue Persistence
+
+## Goal
+Track distinct clue entries for each selectable row and column count (5-40). When a user changes the puzzle size, previously entered clues for that size should reappear. Data persists between launches via `GameState`.
+
+## Steps
+1. **Data Model Changes**
+   - Extend `GameState` to store `rowCluesBySize: [Int:[[Int]]]` and `columnCluesBySize: [Int:[[Int]]]`.
+   - Remove old single `rowClues` and `columnClues` fields.
+2. **GameManager**
+   - Add properties mirroring the new dictionaries plus `rowClues`/`columnClues` for the currently selected size.
+   - Modify initializer and `load()` to populate dictionaries and load the arrays for the saved grid size.
+   - Update `save()` to persist dictionaries.
+   - When `set(rows:columns:)` is called, save current clues to the appropriate dictionary keys then retrieve arrays for the new sizes (or create empty arrays).
+   - Update `updateRowClue` and `updateColumnClue` to update both the current arrays and the dictionaries.
+3. **UI Adjustments**
+   - Display a text field for every row and column of the selected size (remove `min(5, ...)`).
+   - Add `.onSubmit` to each text field so clues are saved after the user presses return.
+4. **Builder & Tests**
+   - Update `GameManagerBuilder` to work with the new model fields.
+   - Adjust existing unit tests for the new `GameState` definition.
+
+This plan enables independent clue sets for each grid size and ensures persistence across launches.

--- a/nonogramSolver-July2025/ClueEntryView.swift
+++ b/nonogramSolver-July2025/ClueEntryView.swift
@@ -11,6 +11,9 @@ struct ClueEntryView: View {
                     get: { manager.rowClues[row].map(String.init).joined(separator: " ") },
                     set: { manager.updateRowClue(row: row, string: $0) }
                 ))
+                    .onSubmit {
+                        manager.updateRowClue(row: row, string: manager.rowClues[row].map(String.init).joined(separator: " "))
+                    }
                     .textFieldStyle(.roundedBorder)
             }
             Text("Column Clues")
@@ -19,6 +22,9 @@ struct ClueEntryView: View {
                     get: { manager.columnClues[column].map(String.init).joined(separator: " ") },
                     set: { manager.updateColumnClue(column: column, string: $0) }
                 ))
+                    .onSubmit {
+                        manager.updateColumnClue(column: column, string: manager.columnClues[column].map(String.init).joined(separator: " "))
+                    }
                     .textFieldStyle(.roundedBorder)
             }
         }

--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -76,7 +76,7 @@ struct ContentView: View {
                             VStack(alignment: .leading) {
                                 Text("Row Clues:")
                                     .font(.subheadline)
-                                ForEach(0..<min(5, manager.grid.rows), id: \.self) { row in
+                                ForEach(0..<manager.grid.rows, id: \.self) { row in
                                     HStack {
                                         Text("R\(row+1):")
                                             .frame(width: 30, alignment: .leading)
@@ -84,6 +84,9 @@ struct ContentView: View {
                                             get: { manager.rowClues[row].map(String.init).joined(separator: " ") },
                                             set: { manager.updateRowClue(row: row, string: $0) }
                                         ))
+                                        .onSubmit {
+                                            manager.updateRowClue(row: row, string: manager.rowClues[row].map(String.init).joined(separator: " "))
+                                        }
                                         .textFieldStyle(.roundedBorder)
                                     }
                                 }
@@ -92,7 +95,7 @@ struct ContentView: View {
                             VStack(alignment: .leading) {
                                 Text("Column Clues:")
                                     .font(.subheadline)
-                                ForEach(0..<min(5, manager.grid.columns), id: \.self) { column in
+                                ForEach(0..<manager.grid.columns, id: \.self) { column in
                                     HStack {
                                         Text("C\(column+1):")
                                             .frame(width: 30, alignment: .leading)
@@ -100,6 +103,9 @@ struct ContentView: View {
                                             get: { manager.columnClues[column].map(String.init).joined(separator: " ") },
                                             set: { manager.updateColumnClue(column: column, string: $0) }
                                         ))
+                                        .onSubmit {
+                                            manager.updateColumnClue(column: column, string: manager.columnClues[column].map(String.init).joined(separator: " "))
+                                        }
                                         .textFieldStyle(.roundedBorder)
                                     }
                                 }

--- a/nonogramSolver-July2025/Data/testing.json
+++ b/nonogramSolver-July2025/Data/testing.json
@@ -10,6 +10,10 @@
       ["unmarked","unmarked","unmarked","unmarked","unmarked"]
     ]
   },
-  "rowClues": [],
-  "columnClues": []
+  "rowCluesBySize": {
+    "5": []
+  },
+  "columnCluesBySize": {
+    "5": []
+  }
 }

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -5,13 +5,18 @@ class GameManager: ObservableObject {
     @Published private(set) var grid: PuzzleGrid
     @Published var rowClues: [[Int]]
     @Published var columnClues: [[Int]]
+    private var rowCluesBySize: [Int: [[Int]]]
+    private var columnCluesBySize: [Int: [[Int]]]
 
     private let store: GameStateStoring
 
-    init(grid: PuzzleGrid, rowClues: [[Int]], columnClues: [[Int]], store: GameStateStoring) {
+    init(grid: PuzzleGrid, rowClues: [[Int]], columnClues: [[Int]], store: GameStateStoring,
+         rowCluesBySize: [Int: [[Int]]] = [:], columnCluesBySize: [Int: [[Int]]] = [:]) {
         self.grid = grid
         self.rowClues = rowClues
         self.columnClues = columnClues
+        self.rowCluesBySize = rowCluesBySize
+        self.columnCluesBySize = columnCluesBySize
         self.store = store
     }
 
@@ -21,26 +26,49 @@ class GameManager: ObservableObject {
         let grid = PuzzleGrid(rows: rows, columns: columns)
         let rowClues = Array(repeating: [Int](), count: rows)
         let columnClues = Array(repeating: [Int](), count: columns)
-        self.init(grid: grid, rowClues: rowClues, columnClues: columnClues, store: store)
+        let rowMap = [rows: rowClues]
+        let columnMap = [columns: columnClues]
+        self.init(grid: grid, rowClues: rowClues, columnClues: columnClues, store: store, rowCluesBySize: rowMap, columnCluesBySize: columnMap)
     }
 
     func load() async {
         if let state = await store.load() {
             self.grid = state.grid
-            self.rowClues = state.rowClues
-            self.columnClues = state.columnClues
+            self.rowCluesBySize = state.rowCluesBySize
+            self.columnCluesBySize = state.columnCluesBySize
+            self.rowClues = state.rowCluesBySize[state.grid.rows] ?? Array(repeating: [Int](), count: state.grid.rows)
+            self.columnClues = state.columnCluesBySize[state.grid.columns] ?? Array(repeating: [Int](), count: state.grid.columns)
         }
     }
 
     func save() async {
-        let state = GameState(grid: grid, rowClues: rowClues, columnClues: columnClues)
+        rowCluesBySize[grid.rows] = rowClues
+        columnCluesBySize[grid.columns] = columnClues
+        let state = GameState(grid: grid, rowCluesBySize: rowCluesBySize, columnCluesBySize: columnCluesBySize)
         await store.save(state)
     }
 
     func set(rows: Int, columns: Int) {
+        // Persist clues for current size
+        rowCluesBySize[grid.rows] = rowClues
+        columnCluesBySize[grid.columns] = columnClues
+
         grid = PuzzleGrid(rows: rows, columns: columns)
-        rowClues = Array(repeating: [Int](), count: rows)
-        columnClues = Array(repeating: [Int](), count: columns)
+
+        if let savedRows = rowCluesBySize[rows] {
+            rowClues = savedRows
+        } else {
+            rowClues = Array(repeating: [Int](), count: rows)
+            rowCluesBySize[rows] = rowClues
+        }
+
+        if let savedColumns = columnCluesBySize[columns] {
+            columnClues = savedColumns
+        } else {
+            columnClues = Array(repeating: [Int](), count: columns)
+            columnCluesBySize[columns] = columnClues
+        }
+
         Task { await save() }
     }
 
@@ -62,11 +90,13 @@ class GameManager: ObservableObject {
 
     func updateRowClue(row: Int, string: String) {
         rowClues[row] = string.split(separator: " ").compactMap { Int($0) }
+        rowCluesBySize[grid.rows] = rowClues
         Task { await save() }
     }
 
     func updateColumnClue(column: Int, string: String) {
         columnClues[column] = string.split(separator: " ").compactMap { Int($0) }
+        columnCluesBySize[grid.columns] = columnClues
         Task { await save() }
     }
 

--- a/nonogramSolver-July2025/GameManagerBuilder.swift
+++ b/nonogramSolver-July2025/GameManagerBuilder.swift
@@ -16,8 +16,10 @@ struct GameManagerBuilder {
         if manager.rowClues.allSatisfy({ $0.isEmpty }),
            let puzzle = loader.loadPuzzle() {
             manager.set(rows: puzzle.grid.rows, columns: puzzle.grid.columns)
-            manager.rowClues = puzzle.rowClues
-            manager.columnClues = puzzle.columnClues
+            manager.rowClues = puzzle.rowCluesBySize[puzzle.grid.rows] ?? Array(repeating: [Int](), count: puzzle.grid.rows)
+            manager.columnClues = puzzle.columnCluesBySize[puzzle.grid.columns] ?? Array(repeating: [Int](), count: puzzle.grid.columns)
+            manager.rowCluesBySize[puzzle.grid.rows] = manager.rowClues
+            manager.columnCluesBySize[puzzle.grid.columns] = manager.columnClues
         }
         return manager
     }

--- a/nonogramSolver-July2025/PuzzleModels.swift
+++ b/nonogramSolver-July2025/PuzzleModels.swift
@@ -20,6 +20,6 @@ struct PuzzleGrid: Codable {
 
 struct GameState: Codable {
     var grid: PuzzleGrid
-    var rowClues: [[Int]]
-    var columnClues: [[Int]]
+    var rowCluesBySize: [Int: [[Int]]]
+    var columnCluesBySize: [Int: [[Int]]]
 }


### PR DESCRIPTION
## Summary
- outline plan for managing clue state by grid size
- store row/column clues keyed by size in `GameState`
- update `GameManager` and builder to load and save those dictionaries
- adjust text fields to show all rows/columns and save on submit
- update sample JSON

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684cd77cecb48330a2d835540e25259f