### PR TITLE
Add unit tests for models and logic

### DIFF
--- a/nonogramSolver-July2025Tests/ModelTests/FlatFileControllerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/FlatFileControllerTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import nonogramSolver_July2025
+
+private struct SimpleValue: Codable, Equatable {
+    let name: String
+}
+
+final class FlatFileControllerTests: XCTestCase {
+    func testSaveAndLoadValue() async throws {
+        let controller = FlatFileController()
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        try? FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
+
+        let value = SimpleValue(name: "test")
+        let fileName = "simple_value.json"
+        try await controller.save(value, to: fileName)
+        let loaded: SimpleValue = try await controller.load(fileName, as: SimpleValue.self)
+        XCTAssertEqual(loaded, value)
+    }
+}

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerBuilderTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerBuilderTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import nonogramSolver_July2025
+
+final class GameManagerBuilderTests: XCTestCase {
+    @MainActor
+    func testBuilderLoadsPuzzleWhenEmpty() async {
+        let grid = PuzzleGrid(rows: 3, columns: 3)
+        let puzzle = GameState(grid: grid, rowCluesBySize: [3: [[1],[2],[3]]], columnCluesBySize: [3: [[1],[2],[3]]])
+        let store = InMemoryGameStateStore()
+        let loader = MockPuzzleLoader(puzzle: puzzle)
+        let builder = GameManagerBuilder(store: store, loader: loader)
+
+        let manager = await builder.build()
+
+        XCTAssertEqual(manager.grid.rows, 3)
+        XCTAssertEqual(manager.rowClues, [[1],[2],[3]])
+        XCTAssertEqual(manager.columnClues, [[1],[2],[3]])
+    }
+}

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import nonogramSolver_July2025
+
+final class GameManagerTests: XCTestCase {
+
+    @MainActor
+    func testUpdateRowAndColumnClues() async {
+        let store = InMemoryGameStateStore()
+        let manager = GameManager(store: store)
+
+        manager.updateRowClue(row: 0, string: "1 2 3")
+        manager.updateColumnClue(column: 0, string: "4 5")
+
+        XCTAssertEqual(manager.rowClues[0], [1,2,3])
+        XCTAssertEqual(manager.columnClues[0], [4,5])
+    }
+
+    @MainActor
+    func testSetGridPersistsClues() async {
+        let store = InMemoryGameStateStore()
+        let manager = GameManager(store: store)
+
+        // update clue for default size (20x15)
+        manager.updateRowClue(row: 0, string: "1")
+        // change size and update clue for new grid
+        manager.set(rows: 2, columns: 2)
+        manager.updateRowClue(row: 0, string: "2")
+
+        // switch back to original size
+        manager.set(rows: 20, columns: 15)
+        await manager.save()
+
+        let loaded = await store.load()
+        XCTAssertEqual(loaded?.rowCluesBySize[20]?[0], [1])
+        XCTAssertEqual(loaded?.rowCluesBySize[2]?[0], [2])
+    }
+}

--- a/nonogramSolver-July2025Tests/ModelTests/GameStateStoreTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameStateStoreTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import Foundation
+@testable import nonogramSolver_July2025
+
+final class GameStateStoreTests: XCTestCase {
+    @MainActor
+    func testSaveAndLoadRoundTrip() async throws {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        try? FileManager.default.createDirectory(at: docs, withIntermediateDirectories: true)
+
+        let grid = PuzzleGrid(rows: 1, columns: 1)
+        let state = GameState(grid: grid, rowCluesBySize: [1: [[]]], columnCluesBySize: [1: [[]]])
+        let store = GameStateStore()
+
+        await store.save(state)
+        let loaded = await store.load()
+
+        XCTAssertEqual(loaded?.grid.rows, state.grid.rows)
+        XCTAssertEqual(loaded?.grid.columns, state.grid.columns)
+    }
+}

--- a/nonogramSolver-July2025Tests/ModelTests/PuzzleGridTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/PuzzleGridTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import nonogramSolver_July2025
+
+final class PuzzleGridTests: XCTestCase {
+    func testInitializationCreatesUnmarkedTiles() throws {
+        let grid = PuzzleGrid(rows: 3, columns: 2)
+        XCTAssertEqual(grid.rows, 3)
+        XCTAssertEqual(grid.columns, 2)
+        XCTAssertEqual(grid.tiles.count, 3)
+        XCTAssertEqual(grid.tiles[0].count, 2)
+        XCTAssertTrue(grid.tiles.flatMap { $0 }.allSatisfy { $0 == .unmarked })
+    }
+}

--- a/nonogramSolver-July2025Tests/ModelTests/PuzzleServiceTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/PuzzleServiceTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import nonogramSolver_July2025
+
+final class PuzzleServiceTests: XCTestCase {
+    func testLoadPuzzleFromBundle() {
+        let service = PuzzleService()
+        let puzzle = service.loadPuzzle()
+        XCTAssertEqual(puzzle?.grid.rows, 5)
+        XCTAssertEqual(puzzle?.grid.columns, 5)
+    }
+}

--- a/nonogramSolver-July2025Tests/TestHelpers.swift
+++ b/nonogramSolver-July2025Tests/TestHelpers.swift
@@ -1,0 +1,21 @@
+import Foundation
+@testable import nonogramSolver_July2025
+
+/// Simple in-memory store for testing persistence.
+actor InMemoryGameStateStore: GameStateStoring {
+    private var state: GameState?
+
+    func save(_ state: GameState) async {
+        self.state = state
+    }
+
+    func load() async -> GameState? {
+        return state
+    }
+}
+
+/// Helper loader that returns a preset puzzle.
+struct MockPuzzleLoader: PuzzleLoading {
+    let puzzle: GameState?
+    func loadPuzzle() -> GameState? { puzzle }
+}

--- a/nonogramSolver-July2025Tests/nonogramSolver_July2025Tests.swift
+++ b/nonogramSolver-July2025Tests/nonogramSolver_July2025Tests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 final class nonogramSolver_July2025Tests: XCTestCase {
 
+    @MainActor
     func testTileCycle() async {
         let manager = GameManager()
         manager.tap(row: 0, column: 0)
@@ -13,6 +14,7 @@ final class nonogramSolver_July2025Tests: XCTestCase {
         XCTAssertEqual(manager.grid.tiles[0][0], .unmarked)
     }
 
+    @MainActor
     func testPersistence() async throws {
         let manager = GameManager()
         manager.tap(row: 0, column: 0)
@@ -28,6 +30,7 @@ final class nonogramSolver_July2025Tests: XCTestCase {
         XCTAssertNotNil(puzzle)
     }
 
+    @MainActor
     func testSetGridSize() async {
         let manager = GameManager()
         manager.set(rows: 10, columns: 12)


### PR DESCRIPTION
## Summary
- test puzzle grid creation
- test game manager functionality and clue persistence
- verify builder loads puzzle
- add persistence, service and file controller tests
- update existing tests for MainActor isolation

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684ce27f36cc833084d646ac096e33fd