### PR TITLE
Add grid clearing feature

### DIFF
--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -52,13 +52,18 @@ struct ContentView: View {
                             
                             // Solve buttons
                             HStack(spacing: 10) {
-                                Button("Auto Solve") { 
-                                    manager.autoSolve() 
+                                Button("Auto Solve") {
+                                    manager.autoSolve()
                                 }
                                 .buttonStyle(.borderedProminent)
-                                
-                                Button("Step Solve") { 
-                                    manager.stepSolve() 
+
+                                Button("Step Solve") {
+                                    manager.stepSolve()
+                                }
+                                .buttonStyle(.bordered)
+
+                                Button("Clear") {
+                                    manager.clearBoard()
                                 }
                                 .buttonStyle(.bordered)
                             }

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -125,6 +125,14 @@ class GameManager: ObservableObject {
         Task { await save() }
     }
 
+    func clearBoard() {
+        grid = PuzzleGrid(rows: grid.rows, columns: grid.columns)
+        solvingRows = true
+        highlightedRow = grid.rows - 1
+        highlightedColumn = nil
+        Task { await save() }
+    }
+
     func autoSolve() {
         // stub
     }

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -34,4 +34,17 @@ final class GameManagerTests: XCTestCase {
         XCTAssertEqual(loaded?.rowCluesBySize[20]?[0], [1])
         XCTAssertEqual(loaded?.rowCluesBySize[2]?[0], [2])
     }
+
+    @MainActor
+    func testClearBoardResetsState() async {
+        let manager = GameManager()
+        manager.tap(row: 0, column: 0)
+        manager.stepSolve()
+
+        manager.clearBoard()
+
+        XCTAssertTrue(manager.grid.tiles.flatMap { $0 }.allSatisfy { $0 == .unmarked })
+        XCTAssertEqual(manager.highlightedRow, manager.grid.rows - 1)
+        XCTAssertNil(manager.highlightedColumn)
+    }
 }


### PR DESCRIPTION
## Summary
- add `clearBoard` method to `GameManager`
- expose new **Clear** button in `ContentView`
- test clearing behavior in `GameManagerTests`

## Testing
- `swift test --parallel` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684cee9df2948330a238a62ae6c32b97