### PR TITLE
Fix column clue order

### DIFF
--- a/nonogramSolver-July2025/NonogramGridComponents.swift
+++ b/nonogramSolver-July2025/NonogramGridComponents.swift
@@ -116,12 +116,13 @@ struct ColumnCluesView: View {
                 )
             ForEach(0..<manager.grid.columns, id: \.self) { column in
                 VStack(spacing: 2) {
-                    Spacer()
-                    ForEach(Array((column < manager.columnClues.count ? manager.columnClues[column] : []).reversed().enumerated()), id: \.offset) { index, clue in
+                    Spacer().frame(maxHeight: 8)
+                    ForEach(Array((column < manager.columnClues.count ? manager.columnClues[column] : []).enumerated()), id: \.offset) { index, clue in
                         Text("\(clue)")
                             .font(.footnote.bold())
                             .foregroundColor(.black)
                     }
+                    Spacer()
                     Spacer().frame(maxHeight: 8)
                 }
                 .frame(width: cellSize, height: maxColumnClueHeight)


### PR DESCRIPTION
## Summary
- correct orientation of the column clues

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf0d1025c83308d65f22bd01445d6