### PR TITLE
Add solving step counter

### DIFF
--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -68,6 +68,8 @@ struct ContentView: View {
                                 .buttonStyle(.bordered)
                             }
                         }
+                        Text("Solving Steps: \(manager.solvingStepCount)")
+                            .font(.caption)
                     }
                     .padding()
                     .background(Color.gray.opacity(0.05))

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -7,6 +7,7 @@ class GameManager: ObservableObject {
     @Published var columnClues: [[Int]]
     @Published var highlightedRow: Int?
     @Published var highlightedColumn: Int?
+    @Published var solvingStepCount: Int = 0
     private var solvingRows = true
     private var rowCluesBySize: [Int: [[Int]]]
     private var columnCluesBySize: [Int: [[Int]]]
@@ -130,6 +131,7 @@ class GameManager: ObservableObject {
         solvingRows = true
         highlightedRow = grid.rows - 1
         highlightedColumn = nil
+        solvingStepCount = 0
         Task { await save() }
     }
 
@@ -146,6 +148,7 @@ class GameManager: ObservableObject {
             guard let row = highlightedRow, row >= 0, row < grid.rows else { return }
 
             solveRow(row)
+            solvingStepCount += 1
 
             if row > 0 {
                 highlightedRow = row - 1
@@ -162,6 +165,7 @@ class GameManager: ObservableObject {
             guard let column = highlightedColumn, column >= 0, column < grid.columns else { return }
 
             solveColumn(column)
+            solvingStepCount += 1
 
             if column < grid.columns - 1 {
                 highlightedColumn = column + 1

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -40,11 +40,13 @@ final class GameManagerTests: XCTestCase {
         let manager = GameManager()
         manager.tap(row: 0, column: 0)
         manager.stepSolve()
+        XCTAssertEqual(manager.solvingStepCount, 1)
 
         manager.clearBoard()
 
         XCTAssertTrue(manager.grid.tiles.flatMap { $0 }.allSatisfy { $0 == .unmarked })
         XCTAssertEqual(manager.highlightedRow, manager.grid.rows - 1)
         XCTAssertNil(manager.highlightedColumn)
+        XCTAssertEqual(manager.solvingStepCount, 0)
     }
 }


### PR DESCRIPTION
## Summary
- show a solving step counter under the solve buttons
- track number of step-solve operations in `GameManager`
- reset the counter when the board is cleared
- test step counter logic

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684cf2a49efc83308b0c4eb57abfb6a9