### PR TITLE
Add puzzle solved state UI

### DIFF
--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -61,6 +61,8 @@ struct ContentView: View {
                                     manager.stepSolve()
                                 }
                                 .buttonStyle(.bordered)
+                                .tint(manager.isPuzzleSolved ? .green : nil)
+                                .disabled(manager.isPuzzleSolved)
 
                                 Button("Clear") {
                                     manager.clearBoard()
@@ -68,8 +70,9 @@ struct ContentView: View {
                                 .buttonStyle(.bordered)
                             }
                         }
-                        Text("Solving Steps: \(manager.solvingStepCount)")
+                        Text(manager.isPuzzleSolved ? "Solved in \(manager.solvingStepCount) steps" : "Solving Steps: \(manager.solvingStepCount)")
                             .font(.caption)
+                            .foregroundColor(manager.isPuzzleSolved ? .green : .primary)
                     }
                     .padding()
                     .background(Color.gray.opacity(0.05))

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -8,6 +8,10 @@ class GameManager: ObservableObject {
     @Published var highlightedRow: Int?
     @Published var highlightedColumn: Int?
     @Published var solvingStepCount: Int = 0
+    /// Returns `true` when no tiles remain in the `.unmarked` state.
+    var isPuzzleSolved: Bool {
+        !grid.tiles.flatMap { $0 }.contains(.unmarked)
+    }
     private var solvingRows = true
     private var rowCluesBySize: [Int: [[Int]]]
     private var columnCluesBySize: [Int: [[Int]]]
@@ -140,6 +144,7 @@ class GameManager: ObservableObject {
     }
 
     func stepSolve() {
+        guard !isPuzzleSolved else { return }
         if solvingRows {
             if highlightedRow == nil {
                 highlightedRow = previousUnsolvedRow(before: grid.rows)

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -65,4 +65,14 @@ final class GameManagerTests: XCTestCase {
         XCTAssertEqual(manager.highlightedRow, 0)
         XCTAssertEqual(manager.solvingStepCount, 1)
     }
+
+    @MainActor
+    func testIsPuzzleSolved() async {
+        let manager = GameManager()
+        manager.set(rows: 2, columns: 2)
+        for r in 0..<2 { for c in 0..<2 { manager.tap(row: r, column: c) } }
+        XCTAssertTrue(manager.isPuzzleSolved)
+        manager.clearBoard()
+        XCTAssertFalse(manager.isPuzzleSolved)
+    }
 }


### PR DESCRIPTION
## Summary
- add `isPuzzleSolved` computed property to detect when all cells are solved
- prevent further steps in `stepSolve()` once puzzle solved
- disable and tint Step Solve button when solved
- show "Solved in X steps" message when puzzle is solved
- unit test for new solved state

## Testing
- `swift test --enable-test-discovery` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684cf51e53b48330bd1c16fb4cde4a0f