### PR TITLE
Handle missing clues during step solve

### DIFF
--- a/nonogramSolver-July2025/NonogramGridComponents.swift
+++ b/nonogramSolver-July2025/NonogramGridComponents.swift
@@ -57,7 +57,10 @@ struct GridCellView: View {
                 ? manager.grid.tiles[row][column].view
                 : TileState.unmarked.view
             )
-            .background(column == manager.highlightedColumn ? Color.yellow.opacity(0.3) : Color.clear)
+            .background(
+                column == manager.errorColumn ? Color.red.opacity(0.3) :
+                (column == manager.highlightedColumn ? Color.yellow.opacity(0.3) : Color.clear)
+            )
             .frame(width: cellSize, height: cellSize)
             .overlay(
                 ZStack {
@@ -125,7 +128,10 @@ struct ColumnCluesView: View {
                     Spacer().frame(maxHeight: 8)
                 }
                 .frame(width: cellSize, height: maxColumnClueHeight)
-                .background(column == manager.highlightedColumn ? Color.yellow.opacity(0.3) : GridStyle.clueBackgroundColor)
+                .background(
+                    column == manager.errorColumn ? Color.red.opacity(0.3) :
+                    (column == manager.highlightedColumn ? Color.yellow.opacity(0.3) : GridStyle.clueBackgroundColor)
+                )
                 .overlay(
                     ZStack {
                         Rectangle()
@@ -169,7 +175,10 @@ struct RowCluesView: View {
                     Spacer().frame(maxWidth: 8)
                 }
                 .frame(width: maxRowClueWidth, height: cellSize)
-                .background(row == manager.highlightedRow ? Color.yellow.opacity(0.3) : GridStyle.clueBackgroundColor)
+                .background(
+                    row == manager.errorRow ? Color.red.opacity(0.3) :
+                    (row == manager.highlightedRow ? Color.yellow.opacity(0.3) : GridStyle.clueBackgroundColor)
+                )
                 .overlay(
                     ZStack {
                         Rectangle()

--- a/nonogramSolver-July2025/NonogramGridView.swift
+++ b/nonogramSolver-July2025/NonogramGridView.swift
@@ -56,7 +56,10 @@ struct NonogramGridView: View {
                                 GridCellView(manager: manager, row: row, column: column, cellSize: cellSize)
                             }
                         }
-                        .background(row == manager.highlightedRow ? Color.yellow.opacity(0.3) : Color.clear)
+                        .background(
+                            row == manager.errorRow ? Color.red.opacity(0.3) :
+                            (row == manager.highlightedRow ? Color.yellow.opacity(0.3) : Color.clear)
+                        )
                     }
                 }
             }

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -75,4 +75,41 @@ final class GameManagerTests: XCTestCase {
         manager.clearBoard()
         XCTAssertFalse(manager.isPuzzleSolved)
     }
+
+    @MainActor
+    func testStepSolveHighlightsMissingRowClue() async {
+        let manager = GameManager()
+        manager.set(rows: 2, columns: 1)
+
+        manager.stepSolve()
+
+        XCTAssertEqual(manager.errorRow, 1)
+        XCTAssertEqual(manager.solvingStepCount, 0)
+
+        manager.stepSolve()
+
+        XCTAssertNil(manager.errorRow)
+        XCTAssertEqual(manager.highlightedRow, 0)
+        XCTAssertEqual(manager.solvingStepCount, 0)
+    }
+
+    @MainActor
+    func testStepSolveHighlightsMissingColumnClue() async {
+        let manager = GameManager()
+        manager.set(rows: 1, columns: 2)
+        manager.updateRowClue(row: 0, string: "1")
+
+        manager.stepSolve() // solve row
+
+        manager.stepSolve() // should flag first column
+
+        XCTAssertEqual(manager.errorColumn, 0)
+        XCTAssertEqual(manager.solvingStepCount, 1)
+
+        manager.stepSolve() // clear flag and move to next column
+
+        XCTAssertNil(manager.errorColumn)
+        XCTAssertEqual(manager.highlightedColumn, 1)
+        XCTAssertEqual(manager.solvingStepCount, 1)
+    }
 }


### PR DESCRIPTION
## Summary
- add errorRow/errorColumn highlighting state
- skip step count and show red highlight when clues are missing
- display red highlight in grid and clue views
- test row and column missing clue behaviour

## Testing
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf6bf021c83308de605c4f841ca1d