### PR TITLE
Add clear clues buttons

### DIFF
--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -85,8 +85,16 @@ struct ContentView: View {
                         
                         HStack {
                             VStack(alignment: .leading) {
-                                Text("Row Clues:")
-                                    .font(.subheadline)
+                                HStack {
+                                    Text("Row Clues:")
+                                        .font(.subheadline)
+                                    Spacer()
+                                    Button("Clear Rows") {
+                                        manager.clearRowClues()
+                                    }
+                                    .font(.caption)
+                                    .buttonStyle(.bordered)
+                                }
                                 ForEach(0..<manager.grid.rows, id: \.self) { row in
                                     HStack {
                                         Text("R\(row+1):")
@@ -106,10 +114,18 @@ struct ContentView: View {
                                     }
                                 }
                             }
-                            
+
                             VStack(alignment: .leading) {
-                                Text("Column Clues:")
-                                    .font(.subheadline)
+                                HStack {
+                                    Text("Column Clues:")
+                                        .font(.subheadline)
+                                    Spacer()
+                                    Button("Clear Columns") {
+                                        manager.clearColumnClues()
+                                    }
+                                    .font(.caption)
+                                    .buttonStyle(.bordered)
+                                }
                                 ForEach(0..<manager.grid.columns, id: \.self) { column in
                                     HStack {
                                         Text("C\(column+1):")

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -135,6 +135,18 @@ class GameManager: ObservableObject {
         Task { await save() }
     }
 
+    func clearRowClues() {
+        rowClues = Array(repeating: [], count: grid.rows)
+        rowCluesBySize[grid.rows] = rowClues
+        Task { await save() }
+    }
+
+    func clearColumnClues() {
+        columnClues = Array(repeating: [], count: grid.columns)
+        columnCluesBySize[grid.columns] = columnClues
+        Task { await save() }
+    }
+
     func clearBoard() {
         grid = PuzzleGrid(rows: grid.rows, columns: grid.columns)
         solvingRows = true

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -112,4 +112,17 @@ final class GameManagerTests: XCTestCase {
         XCTAssertEqual(manager.highlightedColumn, 1)
         XCTAssertEqual(manager.solvingStepCount, 1)
     }
+
+    @MainActor
+    func testClearRowAndColumnClues() async {
+        let manager = GameManager()
+        manager.updateRowClue(row: 0, string: "1 2")
+        manager.updateColumnClue(column: 0, string: "3")
+
+        manager.clearRowClues()
+        manager.clearColumnClues()
+
+        XCTAssertTrue(manager.rowClues.allSatisfy { $0.isEmpty })
+        XCTAssertTrue(manager.columnClues.allSatisfy { $0.isEmpty })
+    }
 }


### PR DESCRIPTION
## Summary
- add GameManager helpers for clearing row/column clues
- add "Clear Rows" and "Clear Columns" buttons in ContentView
- test clearing of clues

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme nonogramSolver-July2025 -sdk macosx -destination 'platform=macOS' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf8de31488330a1426289a43cb176