### PR TITLE
Add contradiction detection to step solver

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -8,6 +8,7 @@ This document captures the current conventions, architecture and specifications 
 - **Persistence**: A `GameStateStore` actor conforming to `GameStateStoring` saves and loads the puzzle state as JSON using `FlatFileController` for atomic disk I/O.
 - **Strict Concurrency**: All state mutations occur on actors or via `@MainActor` objects. `GameManager` is marked `@MainActor`. Persistence actors isolate file operations.
 - **UI Features**: A basic grid view with row/column clues, controls for puzzle size, and placeholder "Auto Solve" and "Step Solve" buttons.
+- **Contradiction Detection**: The step solver halts when clues conflict with the current board and highlights the offending row or column in red.
 - **Builder Pattern**: `GameManagerBuilder` constructs and loads the model before any view accesses it, preventing concurrency issues on startup.
 - **Dependency Injection**: Persistence and puzzle loading use the `GameStateStoring` and `PuzzleLoading` protocols so different implementations can be supplied in tests or future features.
 - **Testing**: Unit tests exist for tile cycling and persistence. UI tests are present but still contain template code.
@@ -20,6 +21,7 @@ These align with the original _MacOS Solver App Development Plan_ in the reposit
   - Exposes methods to mutate the grid (`tap`), update clues, and change puzzle size.
   - Asynchronously saves the state after each mutation.
   - Dependencies for persistence are injected through the `GameStateStoring` protocol for easier testing.
+  - Detects contradictions during step solving. When no valid line permutation exists for a row or column, `contradictionRow` or `contradictionColumn` is set and solving halts until the user updates the clues.
 - **`GameStateStore` & `FlatFileController`**
   - `GameStateStore` implements `GameStateStoring`; `FlatFileController` performs disk I/O with atomic writes.
   - File name is fixed at `gamestate.json` in the user documents directory.

--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -61,7 +61,7 @@ struct ContentView: View {
                                     manager.stepSolve()
                                 }
                                 .buttonStyle(.bordered)
-                                .tint(manager.isPuzzleSolved ? .green : nil)
+                                .tint(manager.contradictionEncountered ? .red : (manager.isPuzzleSolved ? .green : nil))
                                 .disabled(manager.isPuzzleSolved)
 
                                 Button("Clear") {
@@ -70,9 +70,15 @@ struct ContentView: View {
                                 .buttonStyle(.bordered)
                             }
                         }
-                        Text(manager.isPuzzleSolved ? "Solved in \(manager.solvingStepCount) steps" : "Solving Steps: \(manager.solvingStepCount)")
-                            .font(.caption)
-                            .foregroundColor(manager.isPuzzleSolved ? .green : .primary)
+                        if manager.contradictionEncountered {
+                            Text("Contradiction encountered!")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                        } else {
+                            Text(manager.isPuzzleSolved ? "Solved in \(manager.solvingStepCount) steps" : "Solving Steps: \(manager.solvingStepCount)")
+                                .font(.caption)
+                                .foregroundColor(manager.isPuzzleSolved ? .green : .primary)
+                        }
                     }
                     .padding()
                     .background(Color.gray.opacity(0.05))

--- a/nonogramSolver-July2025/NonogramGridComponents.swift
+++ b/nonogramSolver-July2025/NonogramGridComponents.swift
@@ -58,7 +58,7 @@ struct GridCellView: View {
                 : TileState.unmarked.view
             )
             .background(
-                column == manager.errorColumn ? Color.red.opacity(0.3) :
+                (column == manager.errorColumn || column == manager.contradictionColumn) ? Color.red.opacity(0.3) :
                 (column == manager.highlightedColumn ? Color.yellow.opacity(0.3) : Color.clear)
             )
             .frame(width: cellSize, height: cellSize)
@@ -129,7 +129,7 @@ struct ColumnCluesView: View {
                 }
                 .frame(width: cellSize, height: maxColumnClueHeight)
                 .background(
-                    column == manager.errorColumn ? Color.red.opacity(0.3) :
+                    (column == manager.errorColumn || column == manager.contradictionColumn) ? Color.red.opacity(0.3) :
                     (column == manager.highlightedColumn ? Color.yellow.opacity(0.3) : GridStyle.clueBackgroundColor)
                 )
                 .overlay(
@@ -176,7 +176,7 @@ struct RowCluesView: View {
                 }
                 .frame(width: maxRowClueWidth, height: cellSize)
                 .background(
-                    row == manager.errorRow ? Color.red.opacity(0.3) :
+                    (row == manager.errorRow || row == manager.contradictionRow) ? Color.red.opacity(0.3) :
                     (row == manager.highlightedRow ? Color.yellow.opacity(0.3) : GridStyle.clueBackgroundColor)
                 )
                 .overlay(

--- a/nonogramSolver-July2025/NonogramGridView.swift
+++ b/nonogramSolver-July2025/NonogramGridView.swift
@@ -57,7 +57,7 @@ struct NonogramGridView: View {
                             }
                         }
                         .background(
-                            row == manager.errorRow ? Color.red.opacity(0.3) :
+                            (row == manager.errorRow || row == manager.contradictionRow) ? Color.red.opacity(0.3) :
                             (row == manager.highlightedRow ? Color.yellow.opacity(0.3) : Color.clear)
                         )
                     }

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -125,4 +125,37 @@ final class GameManagerTests: XCTestCase {
         XCTAssertTrue(manager.rowClues.allSatisfy { $0.isEmpty })
         XCTAssertTrue(manager.columnClues.allSatisfy { $0.isEmpty })
     }
+
+    @MainActor
+    func testStepSolveDetectsRowContradiction() async {
+        let manager = GameManager()
+        manager.set(rows: 1, columns: 2)
+        manager.clearBoard()
+        manager.updateRowClue(row: 0, string: "3") // impossible
+        manager.updateColumnClue(column: 0, string: "")
+        manager.updateColumnClue(column: 1, string: "")
+
+        manager.stepSolve()
+
+        XCTAssertEqual(manager.contradictionRow, 0)
+        XCTAssertTrue(manager.contradictionEncountered)
+        XCTAssertEqual(manager.solvingStepCount, 0)
+    }
+
+    @MainActor
+    func testStepSolveDetectsColumnContradiction() async {
+        let manager = GameManager()
+        manager.set(rows: 1, columns: 2)
+        manager.clearBoard()
+        manager.updateRowClue(row: 0, string: "1")
+        manager.updateColumnClue(column: 0, string: "3") // impossible
+        manager.updateColumnClue(column: 1, string: "1")
+
+        manager.stepSolve() // process row
+        manager.stepSolve() // process column 0 -> contradiction
+
+        XCTAssertEqual(manager.contradictionColumn, 0)
+        XCTAssertTrue(manager.contradictionEncountered)
+        XCTAssertEqual(manager.solvingStepCount, 1)
+    }
 }


### PR DESCRIPTION
## Summary
- detect contradictions in `GameManager.stepSolve` and highlight offending line
- show contradiction status in `ContentView` and tint Step Solve button red
- highlight rows/columns red when contradictions occur
- document contradiction detection in `DEVELOPER_GUIDE`
- test row and column contradiction handling

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684cff3babac8330a34d372a55b74192