### PR TITLE
Add unsolvable detection feature

### DIFF
--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -61,8 +61,8 @@ struct ContentView: View {
                                     manager.stepSolve()
                                 }
                                 .buttonStyle(.bordered)
-                                .tint(manager.contradictionEncountered ? .red : (manager.isPuzzleSolved ? .green : nil))
-                                .disabled(manager.isPuzzleSolved)
+                                .tint(manager.contradictionEncountered ? .red : (manager.unsolvableByStep ? .orange : (manager.isPuzzleSolved ? .green : nil)))
+                                .disabled(manager.isPuzzleSolved || manager.unsolvableByStep)
 
                                 Button("Clear") {
                                     manager.clearBoard()
@@ -74,6 +74,10 @@ struct ContentView: View {
                             Text("Contradiction encountered!")
                                 .font(.caption)
                                 .foregroundColor(.red)
+                        } else if manager.unsolvableByStep {
+                            Text("Not solvable by this method at \(manager.solvingStepCount) steps")
+                                .font(.caption)
+                                .foregroundColor(.orange)
                         } else {
                             Text(manager.isPuzzleSolved ? "Solved in \(manager.solvingStepCount) steps" : "Solving Steps: \(manager.solvingStepCount)")
                                 .font(.caption)

--- a/nonogramSolver-July2025/NonogramGridComponents.swift
+++ b/nonogramSolver-July2025/NonogramGridComponents.swift
@@ -59,7 +59,7 @@ struct GridCellView: View {
             )
             .background(
                 (column == manager.errorColumn || column == manager.contradictionColumn) ? Color.red.opacity(0.3) :
-                (column == manager.highlightedColumn ? Color.yellow.opacity(0.3) : Color.clear)
+                (column == manager.highlightedColumn ? (manager.unsolvableByStep ? Color.orange.opacity(0.3) : Color.yellow.opacity(0.3)) : Color.clear)
             )
             .frame(width: cellSize, height: cellSize)
             .overlay(
@@ -130,7 +130,7 @@ struct ColumnCluesView: View {
                 .frame(width: cellSize, height: maxColumnClueHeight)
                 .background(
                     (column == manager.errorColumn || column == manager.contradictionColumn) ? Color.red.opacity(0.3) :
-                    (column == manager.highlightedColumn ? Color.yellow.opacity(0.3) : GridStyle.clueBackgroundColor)
+                    (column == manager.highlightedColumn ? (manager.unsolvableByStep ? Color.orange.opacity(0.3) : Color.yellow.opacity(0.3)) : GridStyle.clueBackgroundColor)
                 )
                 .overlay(
                     ZStack {
@@ -177,7 +177,7 @@ struct RowCluesView: View {
                 .frame(width: maxRowClueWidth, height: cellSize)
                 .background(
                     (row == manager.errorRow || row == manager.contradictionRow) ? Color.red.opacity(0.3) :
-                    (row == manager.highlightedRow ? Color.yellow.opacity(0.3) : GridStyle.clueBackgroundColor)
+                    (row == manager.highlightedRow ? (manager.unsolvableByStep ? Color.orange.opacity(0.3) : Color.yellow.opacity(0.3)) : GridStyle.clueBackgroundColor)
                 )
                 .overlay(
                     ZStack {

--- a/nonogramSolver-July2025/NonogramGridView.swift
+++ b/nonogramSolver-July2025/NonogramGridView.swift
@@ -58,7 +58,7 @@ struct NonogramGridView: View {
                         }
                         .background(
                             (row == manager.errorRow || row == manager.contradictionRow) ? Color.red.opacity(0.3) :
-                            (row == manager.highlightedRow ? Color.yellow.opacity(0.3) : Color.clear)
+                            (row == manager.highlightedRow ? (manager.unsolvableByStep ? Color.orange.opacity(0.3) : Color.yellow.opacity(0.3)) : Color.clear)
                         )
                     }
                 }

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -158,4 +158,20 @@ final class GameManagerTests: XCTestCase {
         XCTAssertTrue(manager.contradictionEncountered)
         XCTAssertEqual(manager.solvingStepCount, 1)
     }
+
+    @MainActor
+    func testStepSolveDetectsUnsolvableLoop() async {
+        let manager = GameManager()
+        manager.set(rows: 2, columns: 2)
+        manager.clearBoard()
+        for i in 0..<2 {
+            manager.updateRowClue(row: i, string: "1")
+            manager.updateColumnClue(column: i, string: "1")
+        }
+
+        manager.lastSolvedClues = "R2"
+        for _ in 0..<4 { manager.stepSolve() }
+
+        XCTAssertTrue(manager.unsolvableByStep)
+    }
 }


### PR DESCRIPTION
## Summary
- detect loops with no progress when step-solving
- show orange highlighting and disable the Step Solve button when unsolvable
- update UI messages for unsolvable puzzles
- test unsolvable loop detection

## Testing
- `xcodebuild -project nonogramSolver-July2025.xcodeproj -scheme nonogramSolver-July2025 -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d025fb8b88330802f60e323b490c9