### PR TITLE
Fix unsolvable tracking initialization

### DIFF
--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -40,6 +40,7 @@ class GameManager: ObservableObject {
         self.rowCluesBySize = rowCluesBySize
         self.columnCluesBySize = columnCluesBySize
         self.store = store
+        self.lastSolvedClues = "R\(grid.rows)"
     }
 
     convenience init(store: GameStateStoring = GameStateStore()) {
@@ -100,10 +101,11 @@ class GameManager: ObservableObject {
         // Update all state atomically to prevent race conditions
         // Use objectWillChange to ensure UI updates happen properly
         objectWillChange.send()
-        
+
         grid = newGrid
         rowClues = newRowClues
         columnClues = newColumnClues
+        lastSolvedClues = "R\(rows)"
         
         // Update the dictionaries with the new arrays
         rowCluesBySize[rows] = newRowClues
@@ -172,13 +174,13 @@ class GameManager: ObservableObject {
         grid = PuzzleGrid(rows: grid.rows, columns: grid.columns)
         solvingRows = true
         highlightedRow = grid.rows - 1
+        lastSolvedClues = "R\(grid.rows)"
         highlightedColumn = nil
         errorRow = nil
         errorColumn = nil
         contradictionRow = nil
         contradictionColumn = nil
         contradictionEncountered = false
-        lastSolvedClues = nil
         unsolvableByStep = false
         solvingStepCount = 0
         Task { await save() }

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -169,7 +169,6 @@ final class GameManagerTests: XCTestCase {
             manager.updateColumnClue(column: i, string: "1")
         }
 
-        manager.lastSolvedClues = "R2"
         for _ in 0..<4 { manager.stepSolve() }
 
         XCTAssertTrue(manager.unsolvableByStep)


### PR DESCRIPTION
## Summary
- set `lastSolvedClues` to the bottom row when creating or clearing a puzzle
- update `set(rows:columns:)` to reset the tracker
- remove manual tracker initialization from unsolvable loop test

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift package describe` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684d0a43eb248330bc436394eff98a38