### PR TITLE
Implement auto solver loop

### DIFF
--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -53,9 +53,11 @@ struct ContentView: View {
                             // Solve buttons
                             HStack(spacing: 10) {
                                 Button("Auto Solve") {
-                                    manager.autoSolve()
+                                    Task { await manager.autoSolve() }
                                 }
                                 .buttonStyle(.borderedProminent)
+                                .tint(manager.contradictionEncountered ? .red : (manager.unsolvableByStep ? .orange : (manager.isPuzzleSolved ? .green : nil)))
+                                .disabled(manager.isPuzzleSolved || manager.unsolvableByStep)
 
                                 Button("Step Solve") {
                                     manager.stepSolve()

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -186,8 +186,16 @@ class GameManager: ObservableObject {
         Task { await save() }
     }
 
-    func autoSolve() {
-        // stub
+    func autoSolve() async {
+        while !isPuzzleSolved &&
+              !contradictionEncountered &&
+              !unsolvableByStep {
+            stepSolve()
+            if isPuzzleSolved || contradictionEncountered || unsolvableByStep {
+                break
+            }
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
     }
 
     func stepSolve() {

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -173,4 +173,45 @@ final class GameManagerTests: XCTestCase {
 
         XCTAssertTrue(manager.unsolvableByStep)
     }
+
+    @MainActor
+    func testAutoSolveSolvesPuzzle() async {
+        let manager = GameManager()
+        manager.set(rows: 1, columns: 1)
+        manager.updateRowClue(row: 0, string: "1")
+        manager.updateColumnClue(column: 0, string: "1")
+
+        await manager.autoSolve()
+
+        XCTAssertTrue(manager.isPuzzleSolved)
+        XCTAssertGreaterThan(manager.solvingStepCount, 0)
+    }
+
+    @MainActor
+    func testAutoSolveDetectsContradiction() async {
+        let manager = GameManager()
+        manager.set(rows: 1, columns: 1)
+        manager.updateRowClue(row: 0, string: "3")
+        manager.updateColumnClue(column: 0, string: "1")
+
+        await manager.autoSolve()
+
+        XCTAssertTrue(manager.contradictionEncountered)
+        XCTAssertEqual(manager.contradictionRow, 0)
+    }
+
+    @MainActor
+    func testAutoSolveDetectsUnsolvableLoop() async {
+        let manager = GameManager()
+        manager.set(rows: 2, columns: 2)
+        manager.clearBoard()
+        for i in 0..<2 {
+            manager.updateRowClue(row: i, string: "1")
+            manager.updateColumnClue(column: i, string: "1")
+        }
+
+        await manager.autoSolve()
+
+        XCTAssertTrue(manager.unsolvableByStep)
+    }
 }


### PR DESCRIPTION
## Summary
- implement `autoSolve` to loop through `stepSolve` with a 0.2s delay
- color/tint `Auto Solve` button and disable when solved or unsolvable
- add async unit tests for auto-solver behaviour

## Testing
- `swift test --enable-code-coverage` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684d0dd8a6e08330a1d45844e189203d