### PR TITLE
Add bulk clue entry support

### DIFF
--- a/BulkClueEntry_Plan.md
+++ b/BulkClueEntry_Plan.md
@@ -1,0 +1,29 @@
+# Plan for Bulk Row and Column Clue Entry
+
+## Goal
+Allow users to paste all row or column clues at once using a JSON-like array format. A submission button validates the string, updates the grid size, and populates individual clue fields. Invalid input shows a warning above the entry area.
+
+## Steps
+1. **Parsing & Validation**
+   - Accept text like `[[3], [1, 1], [4]]` for rows or columns.
+   - Parse the string with `JSONDecoder` into `[[Int]]`.
+   - Ensure the outer array length is 5–40 and divisible by 5.
+   - Verify all inner arrays contain only positive integers separated by commas.
+   - On failure, set an error message displayed in red.
+
+2. **GameManager Support**
+   - Add `loadRowClues(_:)` and `loadColumnClues(_:)` methods that:
+     - Call `set(rows:columns:)` to match the array count.
+     - Assign `rowClues`/`columnClues` and update the persistence dictionaries.
+     - Persist via `save()`.
+
+3. **UI Implementation**
+   - Create a `BulkClueEntryView` hosting two `TextEditor` fields labeled "Row Clues Array" and "Column Clues Array" with "Submit Rows" and "Submit Columns" buttons.
+   - Display the validation warning text above each editor when needed.
+   - After successful submission, the existing clue fields in `ContentView` should reflect the loaded arrays automatically via `GameManager`.
+
+4. **Testing**
+   - Add unit tests for the parsing logic and `loadRowClues`/`loadColumnClues` methods.
+   - Update UI tests to paste a sample array and verify clue fields populate correctly.
+
+This approach aligns with the Developer Guide: the UI observes `GameManager`, which performs all state mutations and persistence. The new view introduces no independent state beyond form input and uses `@MainActor` methods to update the model.

--- a/nonogramSolver-July2025/BulkClueEntryView.swift
+++ b/nonogramSolver-July2025/BulkClueEntryView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct BulkClueEntryView: View {
+    @ObservedObject var manager: GameManager
+    @State private var rowText = ""
+    @State private var columnText = ""
+    @State private var rowError: String?
+    @State private var columnError: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: 4) {
+                    if let rowError = rowError {
+                        Text(rowError)
+                            .foregroundColor(.red)
+                            .font(.caption)
+                    }
+                    Text("Row Clues Array:")
+                    TextEditor(text: $rowText)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(height: 80)
+                    Button("Submit Rows") { submitRows() }
+                        .buttonStyle(.borderedProminent)
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    if let columnError = columnError {
+                        Text(columnError)
+                            .foregroundColor(.red)
+                            .font(.caption)
+                    }
+                    Text("Column Clues Array:")
+                    TextEditor(text: $columnText)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(height: 80)
+                    Button("Submit Columns") { submitColumns() }
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Bulk Entry")
+    }
+
+    private func submitRows() {
+        if let clues = BulkClueParser.parse(rowText) {
+            manager.loadRowClues(clues)
+            rowError = nil
+        } else {
+            rowError = "Invalid row clue array"
+        }
+    }
+
+    private func submitColumns() {
+        if let clues = BulkClueParser.parse(columnText) {
+            manager.loadColumnClues(clues)
+            columnError = nil
+        } else {
+            columnError = "Invalid column clue array"
+        }
+    }
+}
+
+#Preview {
+    BulkClueEntryView(manager: GameManager())
+}

--- a/nonogramSolver-July2025/BulkClueParser.swift
+++ b/nonogramSolver-July2025/BulkClueParser.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct BulkClueParser {
+    static func parse(_ string: String) -> [[Int]]? {
+        guard let data = string.data(using: .utf8) else { return nil }
+        do {
+            let clues = try JSONDecoder().decode([[Int]].self, from: data)
+            guard clues.count >= 5,
+                  clues.count <= 40,
+                  clues.count % 5 == 0,
+                  clues.allSatisfy({ $0.allSatisfy { $0 > 0 } }) else {
+                return nil
+            }
+            return clues
+        } catch {
+            return nil
+        }
+    }
+}

--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -158,6 +158,10 @@ struct ContentView: View {
                                 }
                             }
                         }
+                        NavigationLink("Bulk Entry") {
+                            BulkClueEntryView(manager: manager)
+                        }
+                        .buttonStyle(.bordered)
                     }
                     .padding()
                     .background(Color.gray.opacity(0.1))

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -170,6 +170,20 @@ class GameManager: ObservableObject {
         Task { await save() }
     }
 
+    func loadRowClues(_ clues: [[Int]]) {
+        set(rows: clues.count, columns: grid.columns)
+        rowClues = clues
+        rowCluesBySize[grid.rows] = clues
+        Task { await save() }
+    }
+
+    func loadColumnClues(_ clues: [[Int]]) {
+        set(rows: grid.rows, columns: clues.count)
+        columnClues = clues
+        columnCluesBySize[grid.columns] = clues
+        Task { await save() }
+    }
+
     func clearBoard() {
         grid = PuzzleGrid(rows: grid.rows, columns: grid.columns)
         solvingRows = true

--- a/nonogramSolver-July2025Tests/ModelTests/BulkClueEntryTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/BulkClueEntryTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import nonogramSolver_July2025
+
+final class BulkClueEntryTests: XCTestCase {
+    func testParserParsesValidArray() {
+        let text = "[[1],[2,3],[4],[5],[6]]"
+        let result = BulkClueParser.parse(text)
+        XCTAssertEqual(result, [[1],[2,3],[4],[5],[6]])
+    }
+
+    func testParserRejectsInvalidArray() {
+        let text = "[[1],[-2]]" // negative number and invalid count
+        XCTAssertNil(BulkClueParser.parse(text))
+    }
+
+    @MainActor
+    func testLoadRowAndColumnClues() async {
+        let store = InMemoryGameStateStore()
+        let manager = GameManager(store: store)
+        manager.loadRowClues([[1],[2],[3],[4],[5]])
+        manager.loadColumnClues([[1],[1],[1],[1],[1]])
+        await manager.save()
+
+        XCTAssertEqual(manager.grid.rows, 5)
+        XCTAssertEqual(manager.grid.columns, 5)
+        XCTAssertEqual(manager.rowClues[0], [1])
+        let saved = await store.load()
+        XCTAssertEqual(saved?.rowCluesBySize[5]?.count, 5)
+        XCTAssertEqual(saved?.columnCluesBySize[5]?.count, 5)
+    }
+}


### PR DESCRIPTION
## Summary
- add parsing helper for bulk clue arrays
- implement `loadRowClues` and `loadColumnClues`
- provide a new `BulkClueEntryView`
- integrate bulk entry navigation
- test parsing and loading logic

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d796d72b08330993716fa12794d42