### PR TITLE
Handle whitespace in bulk clue parsing

### DIFF
--- a/nonogramSolver-July2025/BulkClueParser.swift
+++ b/nonogramSolver-July2025/BulkClueParser.swift
@@ -2,7 +2,9 @@ import Foundation
 
 struct BulkClueParser {
     static func parse(_ string: String) -> [[Int]]? {
-        guard let data = string.data(using: .utf8) else { return nil }
+        // Remove common whitespace characters so pretty printed JSON still parses
+        let cleaned = string.filter { !$0.isWhitespace }
+        guard let data = cleaned.data(using: .utf8) else { return nil }
         do {
             let clues = try JSONDecoder().decode([[Int]].self, from: data)
             guard clues.count >= 5,

--- a/nonogramSolver-July2025Tests/ModelTests/BulkClueEntryTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/BulkClueEntryTests.swift
@@ -8,6 +8,12 @@ final class BulkClueEntryTests: XCTestCase {
         XCTAssertEqual(result, [[1],[2,3],[4],[5],[6]])
     }
 
+    func testParserIgnoresWhitespace() {
+        let text = "\n  [[1], [2],\n   [3], [4],\n   [5]]  "
+        let result = BulkClueParser.parse(text)
+        XCTAssertEqual(result, [[1],[2],[3],[4],[5]])
+    }
+
     func testParserRejectsInvalidArray() {
         let text = "[[1],[-2]]" // negative number and invalid count
         XCTAssertNil(BulkClueParser.parse(text))


### PR DESCRIPTION
## Summary
- strip whitespace when parsing bulk clue JSON
- cover whitespace parsing with a new unit test

## Testing
- `swift --version`
- _Tests could not be executed because xcodebuild is unavailable_


------
https://chatgpt.com/codex/tasks/task_e_684d8f4c5d248330bd8aa9e3339c8861