### PR TITLE
Improve bulk clue import error reporting

### DIFF
--- a/nonogramSolver-July2025/BulkClueEntryView.swift
+++ b/nonogramSolver-July2025/BulkClueEntryView.swift
@@ -43,20 +43,22 @@ struct BulkClueEntryView: View {
     }
 
     private func submitRows() {
-        if let clues = BulkClueParser.parse(rowText) {
+        switch BulkClueParser.parse(rowText) {
+        case .success(let clues):
             manager.loadRowClues(clues)
             rowError = nil
-        } else {
-            rowError = "Invalid row clue array"
+        case .failure(let error):
+            rowError = "Failed: \(error.errorDescription ?? "Unknown error")"
         }
     }
 
     private func submitColumns() {
-        if let clues = BulkClueParser.parse(columnText) {
+        switch BulkClueParser.parse(columnText) {
+        case .success(let clues):
             manager.loadColumnClues(clues)
             columnError = nil
-        } else {
-            columnError = "Invalid column clue array"
+        case .failure(let error):
+            columnError = "Failed: \(error.errorDescription ?? "Unknown error")"
         }
     }
 }

--- a/nonogramSolver-July2025/BulkClueParser.swift
+++ b/nonogramSolver-July2025/BulkClueParser.swift
@@ -1,21 +1,45 @@
 import Foundation
 
 struct BulkClueParser {
-    static func parse(_ string: String) -> [[Int]]? {
+    enum ParseError: LocalizedError, Equatable {
+        case invalidEncoding
+        case invalidJSON
+        case tooFew
+        case tooMany
+        case notMultipleOfFive
+        case nonPositiveNumbers
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidEncoding:
+                return "Unable to decode text"
+            case .invalidJSON:
+                return "Invalid JSON"
+            case .tooFew:
+                return "JSON must contain at least 5 arrays"
+            case .tooMany:
+                return "JSON cannot exceed 40 arrays"
+            case .notMultipleOfFive:
+                return "JSON does not contain a multiple of 5"
+            case .nonPositiveNumbers:
+                return "Clue numbers must all be positive"
+            }
+        }
+    }
+
+    static func parse(_ string: String) -> Result<[[Int]], ParseError> {
         // Remove common whitespace characters so pretty printed JSON still parses
         let cleaned = string.filter { !$0.isWhitespace }
-        guard let data = cleaned.data(using: .utf8) else { return nil }
+        guard let data = cleaned.data(using: .utf8) else { return .failure(.invalidEncoding) }
         do {
             let clues = try JSONDecoder().decode([[Int]].self, from: data)
-            guard clues.count >= 5,
-                  clues.count <= 40,
-                  clues.count % 5 == 0,
-                  clues.allSatisfy({ $0.allSatisfy { $0 > 0 } }) else {
-                return nil
-            }
-            return clues
+            guard clues.count >= 5 else { return .failure(.tooFew) }
+            guard clues.count <= 40 else { return .failure(.tooMany) }
+            guard clues.count % 5 == 0 else { return .failure(.notMultipleOfFive) }
+            guard clues.allSatisfy({ $0.allSatisfy { $0 > 0 } }) else { return .failure(.nonPositiveNumbers) }
+            return .success(clues)
         } catch {
-            return nil
+            return .failure(.invalidJSON)
         }
     }
 }

--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -196,20 +196,22 @@ struct ContentView: View {
     }
 
     private func submitBulkRows() {
-        if let clues = BulkClueParser.parse(bulkRowText) {
+        switch BulkClueParser.parse(bulkRowText) {
+        case .success(let clues):
             manager.loadRowClues(clues)
             bulkRowError = nil
-        } else {
-            bulkRowError = "Invalid row clue array"
+        case .failure(let error):
+            bulkRowError = "Failed: \(error.errorDescription ?? "Unknown error")"
         }
     }
 
     private func submitBulkColumns() {
-        if let clues = BulkClueParser.parse(bulkColumnText) {
+        switch BulkClueParser.parse(bulkColumnText) {
+        case .success(let clues):
             manager.loadColumnClues(clues)
             bulkColumnError = nil
-        } else {
-            bulkColumnError = "Invalid column clue array"
+        case .failure(let error):
+            bulkColumnError = "Failed: \(error.errorDescription ?? "Unknown error")"
         }
     }
 }

--- a/nonogramSolver-July2025Tests/ModelTests/BulkClueEntryTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/BulkClueEntryTests.swift
@@ -5,18 +5,34 @@ final class BulkClueEntryTests: XCTestCase {
     func testParserParsesValidArray() {
         let text = "[[1],[2,3],[4],[5],[6]]"
         let result = BulkClueParser.parse(text)
-        XCTAssertEqual(result, [[1],[2,3],[4],[5],[6]])
+        switch result {
+        case .success(let clues):
+            XCTAssertEqual(clues, [[1],[2,3],[4],[5],[6]])
+        default:
+            XCTFail("Expected success")
+        }
     }
 
     func testParserIgnoresWhitespace() {
         let text = "\n  [[1], [2],\n   [3], [4],\n   [5]]  "
         let result = BulkClueParser.parse(text)
-        XCTAssertEqual(result, [[1],[2],[3],[4],[5]])
+        switch result {
+        case .success(let clues):
+            XCTAssertEqual(clues, [[1],[2],[3],[4],[5]])
+        default:
+            XCTFail("Expected success")
+        }
     }
 
     func testParserRejectsInvalidArray() {
         let text = "[[1],[-2]]" // negative number and invalid count
-        XCTAssertNil(BulkClueParser.parse(text))
+        let result = BulkClueParser.parse(text)
+        switch result {
+        case .failure(let error):
+            XCTAssertEqual(error, .nonPositiveNumbers)
+        default:
+            XCTFail("Expected failure")
+        }
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- improve `BulkClueParser.parse` to return `Result` with detailed `ParseError`
- display detailed failure messages in `BulkClueEntryView` and `ContentView`
- update unit tests for the new parser API

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684d914b6b648330b99c54e90b2e49ad