### PR TITLE
Add puzzle export JSON view

### DIFF
--- a/json_export.md
+++ b/json_export.md
@@ -1,0 +1,25 @@
+# Plan for JSON Export of Solved Puzzle
+
+## Goal
+Add a view showing the solved puzzle as JSON so users can copy the result. When the board has no `.unmarked` tiles (`isPuzzleSolved` from the Developer Guide) a read‑only text region appears to the right of the puzzle grid. The JSON is an array of arrays with `1` for `.filled` and `0` for other tiles.
+
+## Steps
+1. **Model Helper**
+   - Extend `GameManager` with a computed property `solvedGridJSON`.
+   - Convert `grid.tiles` to `[[Int]]` where `.filled` -> `1`, others -> `0`.
+   - Encode with `JSONEncoder` using `.prettyPrinted` formatting and return the string.
+
+2. **UI Layout**
+   - Update `ContentView` so `NonogramGridView` and the export text appear in an `HStack`.
+   - When `manager.isPuzzleSolved` is `true`, display a `ScrollView` containing the JSON string using a monospaced font and `.textSelection(.enabled)`.
+   - Keep the existing controls and clue entry sections below the grid as described in the Developer Guide.
+
+3. **Styling**
+   - Limit the export area's width (~250pt) and give it a light background with padding.
+   - The text window should not be editable but allow copying.
+
+4. **Testing**
+   - Run existing unit tests to ensure no regressions.
+   - Manually verify that after solving a sample puzzle, the JSON appears and matches the expected format.
+
+This approach follows the Developer Guide's model‑driven architecture: `ContentView` observes `GameManager` and simply presents the new data without owning additional state.

--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -15,8 +15,22 @@ struct ContentView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 20) {
-                    NonogramGridView(manager: manager)
-                    
+                    HStack(alignment: .top, spacing: 20) {
+                        NonogramGridView(manager: manager)
+
+                        if manager.isPuzzleSolved {
+                            ScrollView {
+                                Text(manager.solvedGridJSON)
+                                    .font(.system(.body, design: .monospaced))
+                                    .textSelection(.enabled)
+                                    .padding()
+                            }
+                            .frame(width: 250)
+                            .background(Color.gray.opacity(0.1))
+                            .cornerRadius(8)
+                        }
+                    }
+
                     VStack(spacing: 15) {
                     // Grid controls and solve buttons
                     VStack(spacing: 10) {

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -21,6 +21,20 @@ class GameManager: ObservableObject {
     var isPuzzleSolved: Bool {
         !grid.tiles.flatMap { $0 }.contains(.unmarked)
     }
+
+    /// JSON representation of the solved grid using 1 for filled and 0 for empty.
+    var solvedGridJSON: String {
+        let intGrid = grid.tiles.map { row in
+            row.map { $0 == .filled ? 1 : 0 }
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        guard let data = try? encoder.encode(intGrid),
+              let string = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return string
+    }
     private var solvingRows = true
     private var rowCluesBySize: [Int: [[Int]]]
     private var columnCluesBySize: [Int: [[Int]]]


### PR DESCRIPTION
## Summary
- outline JSON export feature
- expose `solvedGridJSON` on `GameManager`
- show read-only JSON to the right of the grid once the puzzle is solved

## Testing
- `xcodebuild` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_684ef38a8ed48330be21bf9ac3c542ca