### PR TITLE
Enable JSON export regardless of solve state

### DIFF
--- a/json_export.md
+++ b/json_export.md
@@ -1,17 +1,17 @@
-# Plan for JSON Export of Solved Puzzle
+# Plan for JSON Export of Puzzle State
 
 ## Goal
-Provide a simple way to copy the solved puzzle as JSON. When the board has no `.unmarked` tiles (`isPuzzleSolved` from the Developer Guide) a green "Export Solution to JSON" button becomes enabled. Pressing it copies an array of arrays using `1` for `.filled` and `0` for other tiles to the macOS clipboard.
+Provide a simple way to copy the current puzzle grid as JSON. A green "Export Grid to JSON" button is always enabled. Pressing it copies an array of arrays using `1` for `.filled` and `0` for `.empty` or `.unmarked` tiles to the macOS clipboard.
 
 ## Steps
 1. **Model Helper**
-   - Extend `GameManager` with a computed property `solvedGridJSON`.
+   - Extend `GameManager` with a computed property `gridJSON`.
    - Convert `grid.tiles` to `[[Int]]` where `.filled` -> `1`, others -> `0`.
    - Encode with `JSONEncoder` using `.prettyPrinted` formatting and return the string.
 
 2. **UI Layout**
-   - Add an "Export Solution to JSON" button beside the puzzle grid.
-   - The button is disabled and gray until `manager.isPuzzleSolved` becomes `true`, after which it turns green.
+   - Add an "Export Grid to JSON" button beside the puzzle grid.
+   - The button is always green and enabled regardless of puzzle state.
    - Keep the existing controls and clue entry sections below the grid as described in the Developer Guide.
 
 3. **Styling**

--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -18,13 +18,12 @@ struct ContentView: View {
                     HStack(alignment: .top, spacing: 20) {
                         NonogramGridView(manager: manager)
 
-                        Button("Export Solution to JSON") {
-                            manager.copySolutionToClipboard()
+                        Button("Export Grid to JSON") {
+                            manager.copyGridToClipboard()
                         }
                         .frame(width: 250)
                         .buttonStyle(.borderedProminent)
-                        .tint(manager.isPuzzleSolved ? .green : .gray)
-                        .disabled(!manager.isPuzzleSolved)
+                        .tint(.green)
                     }
 
                     VStack(spacing: 15) {

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -23,15 +23,16 @@ class GameManager: ObservableObject {
         !grid.tiles.flatMap { $0 }.contains(.unmarked)
     }
 
-    /// JSON representation of the solved grid using 1 for filled and 0 for empty.
-    /// The result formats each row on a single line like:
+    /// JSON representation of the current grid using `1` for `.filled` tiles and
+    /// `0` for both `.empty` and `.unmarked`. The result formats each row on a
+    /// single line like:
     /// ````
     /// [
     ///     [0,1,1],
     ///     [1,0,0]
     /// ]
     /// ````
-    var solvedGridJSON: String {
+    var gridJSON: String {
         let intGrid = grid.tiles.map { row in
             row.map { $0 == .filled ? 1 : 0 }
         }
@@ -41,11 +42,11 @@ class GameManager: ObservableObject {
         return "[\n" + rowStrings.joined(separator: ",\n") + "\n]"
     }
 
-    /// Copies the solved grid JSON representation to the system pasteboard.
-    func copySolutionToClipboard() {
+    /// Copies the grid JSON representation to the system pasteboard.
+    func copyGridToClipboard() {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(solvedGridJSON, forType: .string)
+        pasteboard.setString(gridJSON, forType: .string)
     }
     private var solvingRows = true
     private var rowCluesBySize: [Int: [[Int]]]


### PR DESCRIPTION
## Summary
- let users export the grid to JSON at all times
- change export button to always be green and enabled
- rename helper to `gridJSON` and `copyGridToClipboard`
- update JSON export documentation

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project nonogramSolver-July2025.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f62c62ba48330953dd6168b4af64e