### PR TITLE
Add clue export JSON function

### DIFF
--- a/nonogramSolver-July2025/ContentView.swift
+++ b/nonogramSolver-July2025/ContentView.swift
@@ -24,6 +24,13 @@ struct ContentView: View {
                         .frame(width: 250)
                         .buttonStyle(.borderedProminent)
                         .tint(.green)
+
+                        Button("Export Clues to JSON") {
+                            manager.copyCluesToClipboard()
+                        }
+                        .frame(width: 250)
+                        .buttonStyle(.borderedProminent)
+                        .tint(manager.hasCompleteClues ? .green : .gray)
                     }
 
                     VStack(spacing: 15) {

--- a/nonogramSolver-July2025/GameManager.swift
+++ b/nonogramSolver-July2025/GameManager.swift
@@ -42,11 +42,43 @@ class GameManager: ObservableObject {
         return "[\n" + rowStrings.joined(separator: ",\n") + "\n]"
     }
 
+    /// JSON representation of the current row and column clues. The output is
+    /// pretty printed and has the form:
+    /// ```
+    /// {
+    ///   "rowClues": [[1],[2]],
+    ///   "columnClues": [[1],[2]]
+    /// }
+    /// ```
+    var cluesJSON: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        let object = ["rowClues": rowClues, "columnClues": columnClues]
+        guard let data = try? encoder.encode(object),
+              let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
+    }
+
+    /// Returns `true` when every row and every column contains at least one
+    /// clue number.
+    var hasCompleteClues: Bool {
+        rowClues.allSatisfy { !$0.isEmpty } && columnClues.allSatisfy { !$0.isEmpty }
+    }
+
     /// Copies the grid JSON representation to the system pasteboard.
     func copyGridToClipboard() {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(gridJSON, forType: .string)
+    }
+
+    /// Copies the clues JSON representation to the system pasteboard.
+    func copyCluesToClipboard() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(cluesJSON, forType: .string)
     }
     private var solvingRows = true
     private var rowCluesBySize: [Int: [[Int]]]

--- a/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
+++ b/nonogramSolver-July2025Tests/ModelTests/GameManagerTests.swift
@@ -230,4 +230,25 @@ final class GameManagerTests: XCTestCase {
 
         XCTAssertTrue(manager.unsolvableByStep)
     }
+
+    @MainActor
+    func testHasCompleteCluesAndCluesJSON() async throws {
+        let manager = GameManager()
+        manager.set(rows: 2, columns: 2)
+
+        XCTAssertFalse(manager.hasCompleteClues)
+
+        for i in 0..<2 {
+            manager.updateRowClue(row: i, string: "1")
+            manager.updateColumnClue(column: i, string: "1")
+        }
+
+        XCTAssertTrue(manager.hasCompleteClues)
+
+        let jsonData = manager.cluesJSON.data(using: .utf8)!
+        struct Clues: Decodable { let rowClues: [[Int]]; let columnClues: [[Int]] }
+        let decoded = try JSONDecoder().decode(Clues.self, from: jsonData)
+        XCTAssertEqual(decoded.rowClues.count, 2)
+        XCTAssertEqual(decoded.columnClues.count, 2)
+    }
 }


### PR DESCRIPTION
## Summary
- support exporting row and column clues to JSON
- show `Export Clues to JSON` button beside grid
- tint the clue export button green once every row and column has at least one clue
- test `hasCompleteClues` and `cluesJSON`

## Testing
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f6765ac448330a958acb717963e0b